### PR TITLE
fix: 修复 TextInjector 剪贴板恢复 changeCount 自身比较 bug

### DIFF
--- a/client/Sources/TextInjector.swift
+++ b/client/Sources/TextInjector.swift
@@ -17,6 +17,9 @@ enum TextInjector {
         pb.clearContents()
         pb.setString(text, forType: .string)
 
+        // 记录粘贴后的 changeCount，用于恢复时判断剪贴板是否被其他操作修改
+        let changeCountAfterPaste = pb.changeCount
+
         // 模拟 Cmd+V 粘贴
         let source = CGEventSource(stateID: .hidSystemState)
         let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 0x09, keyDown: true)
@@ -31,7 +34,7 @@ enum TextInjector {
         // 延迟恢复剪贴板
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             // 只在剪贴板没被其他操作修改时恢复
-            if pb.changeCount == pb.changeCount, let saved = savedString {
+            if pb.changeCount == changeCountAfterPaste, let saved = savedString {
                 pb.clearContents()
                 pb.setString(saved, forType: .string)
             }


### PR DESCRIPTION
## Summary

- 修复 `TextInjector.swift` 中 `pb.changeCount == pb.changeCount` 永远为 `true` 的 bug
- 改为粘贴后保存 `changeCount`，恢复时与当前值比较

## 问题

原代码：
```swift
if pb.changeCount == pb.changeCount, let saved = savedString {
```
这是自身与自身比较，永远为 `true`，导致：
- 剪贴板恢复检查形同虚设
- 用户在 0.5s 内复制的内容会被覆盖

## 修复

```swift
let changeCountAfterPaste = pb.changeCount
// ...
if pb.changeCount == changeCountAfterPaste, let saved = savedString {
```

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)