### PR TITLE
feat: per-app 纠错适配 + TextInjector 三级 fallback + 终端 shell hook

### DIFF
--- a/client/Sources/CaptureProfile.swift
+++ b/client/Sources/CaptureProfile.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Per-app 纠错捕获策略
+///
+/// 不同 App 的提交行为差异很大：
+/// - IM 类（微信/Telegram/Slack）：Enter 发送
+/// - 终端（Terminal/Ghostty）：Enter 执行命令，需要 edit-detection 模式
+/// - 编辑器（VS Code/Xcode）：Cmd+Enter 运行
+/// - 笔记类（Notes/TextEdit）：无提交信号，靠 focusChange 或超时
+struct CaptureProfile: Sendable {
+
+    enum SubmitSignal: String, Sendable {
+        case enter          // Enter 键
+        case cmdEnter       // Cmd+Enter
+        case focusChange    // 用户切走应用
+        case none           // 无提交信号，仅靠超时
+    }
+
+    let bundleID: String
+    let submitSignal: SubmitSignal
+    let captureTimeout: TimeInterval
+    let enabled: Bool
+
+    /// 未知 App 的默认 profile
+    static let `default` = CaptureProfile(
+        bundleID: "*",
+        submitSignal: .enter,
+        captureTimeout: 30,
+        enabled: true
+    )
+
+    /// 内置 App 适配表（基于实际使用经验）
+    static let builtIn: [CaptureProfile] = [
+        // 终端类：Enter 执行命令，用 edit-detection + shell hook
+        CaptureProfile(bundleID: "com.apple.Terminal", submitSignal: .enter, captureTimeout: 30, enabled: true),
+        CaptureProfile(bundleID: "com.googlecode.iterm2", submitSignal: .enter, captureTimeout: 30, enabled: true),
+        CaptureProfile(bundleID: "com.mitchellh.ghostty", submitSignal: .enter, captureTimeout: 30, enabled: true),
+
+        // IM 类：Enter 发送，超时短一些
+        CaptureProfile(bundleID: "com.tencent.xinWeChat", submitSignal: .enter, captureTimeout: 15, enabled: true),
+        CaptureProfile(bundleID: "com.tinyspeck.slackmacgap", submitSignal: .enter, captureTimeout: 15, enabled: true),
+        CaptureProfile(bundleID: "com.apple.MobileSMS", submitSignal: .enter, captureTimeout: 15, enabled: true),
+        CaptureProfile(bundleID: "ru.keepcoder.Telegram", submitSignal: .enter, captureTimeout: 15, enabled: true),
+
+        // 笔记/编辑器类：无明确提交信号，切换应用时捕获
+        CaptureProfile(bundleID: "com.apple.Notes", submitSignal: .focusChange, captureTimeout: 60, enabled: true),
+        CaptureProfile(bundleID: "com.apple.TextEdit", submitSignal: .focusChange, captureTimeout: 60, enabled: true),
+
+        // IDE 类：Cmd+Enter
+        CaptureProfile(bundleID: "com.microsoft.VSCode", submitSignal: .cmdEnter, captureTimeout: 30, enabled: true),
+        CaptureProfile(bundleID: "com.apple.dt.Xcode", submitSignal: .cmdEnter, captureTimeout: 30, enabled: true),
+
+        // 浏览器
+        CaptureProfile(bundleID: "com.apple.Safari", submitSignal: .enter, captureTimeout: 30, enabled: true),
+        CaptureProfile(bundleID: "com.google.Chrome", submitSignal: .enter, captureTimeout: 30, enabled: true),
+    ]
+
+    /// 按 bundleID 查找 profile
+    static func profile(for bundleID: String) -> CaptureProfile {
+        builtIn.first { $0.bundleID == bundleID } ?? .default
+    }
+}

--- a/client/Sources/TerminalCorrectionBridge.swift
+++ b/client/Sources/TerminalCorrectionBridge.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// 终端纠错桥接
+///
+/// 解决终端 App 纠错捕获的根本问题：
+/// Enter 后命令已提交给 shell，AX buffer 可能已经有输出，无法可靠读取用户输入。
+///
+/// 工作流：
+/// 1. CorrectionCapture 检测到终端 App 且 prompt 识别失败
+/// 2. 写 pending 文件到 ~/.we/pending-terminal.json
+/// 3. zsh preexec hook 读 pending → 对比实际执行的命令 → 写 corrections
+/// 4. 下次 VoicePipeline 运行时导入 corrections
+enum TerminalCorrectionBridge {
+
+    private static let pendingURL = WEDataDir.url.appendingPathComponent("pending-terminal.json")
+    private static let correctionsURL = WEDataDir.url.appendingPathComponent("terminal-corrections.jsonl")
+
+    /// 写 pending 记录（由 CorrectionCapture 调用）
+    static func writePending(insertedText: String, rawText: String, app: AppIdentity?) {
+        let record: [String: Any] = [
+            "inserted_text": insertedText,
+            "raw_text": rawText,
+            "app_bundle_id": app?.bundleID ?? "",
+            "app_name": app?.appName ?? "",
+            "timestamp": ISO8601DateFormatter().string(from: Date())
+        ]
+
+        guard let data = try? JSONSerialization.data(withJSONObject: record, options: [.prettyPrinted]) else {
+            Logger.log("Bridge", "Failed to serialize pending record")
+            return
+        }
+
+        do {
+            try data.write(to: pendingURL, options: .atomic)
+            Logger.log("Bridge", "Pending terminal capture written: \"\(insertedText)\"")
+        } catch {
+            Logger.log("Bridge", "Failed to write pending: \(error)")
+        }
+    }
+
+    /// 清除 pending 文件
+    static func clearPending() {
+        try? FileManager.default.removeItem(at: pendingURL)
+    }
+
+    /// 导入 shell hook 写的 corrections（由 VoicePipeline 调用）
+    static func importShellCorrections() {
+        guard FileManager.default.fileExists(atPath: correctionsURL.path) else { return }
+
+        guard let data = try? Data(contentsOf: correctionsURL),
+              let content = String(data: data, encoding: .utf8) else { return }
+
+        var imported = 0
+        for line in content.components(separatedBy: "\n") where !line.isEmpty {
+            guard let lineData = line.data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+                  let insertedText = json["inserted_text"] as? String,
+                  let userCommand = json["user_command"] as? String,
+                  insertedText != userCommand else { continue }
+
+            let entry = CorrectionStore.CorrectionEntry(
+                id: UUID().uuidString,
+                timestamp: Date(),
+                rawText: json["raw_text"] as? String ?? insertedText,
+                insertedText: insertedText,
+                correctedText: userCommand,
+                appBundleID: json["app_bundle_id"] as? String ?? "",
+                quality: json["quality"] as? Double ?? 0.8
+            )
+            CorrectionStore.shared.save(entry)
+            imported += 1
+        }
+
+        if imported > 0 {
+            Logger.log("Bridge", "Imported \(imported) terminal corrections")
+            // 清空已导入的 corrections
+            try? FileManager.default.removeItem(at: correctionsURL)
+        }
+    }
+}

--- a/client/Sources/TextInjector.swift
+++ b/client/Sources/TextInjector.swift
@@ -1,23 +1,152 @@
 import AppKit
 
 /// 文本注入器
-/// 使用 clipboard + Cmd+V 粘贴（最可靠的通用方式）
-/// 粘贴后恢复原剪贴板内容
+///
+/// 三级 fallback 策略：
+/// 1. AX 插入 (kAXSelectedTextAttribute) — 不动剪贴板，最干净
+/// 2. AX 菜单 (Edit > Paste) — 绕过 Secure Keyboard Entry（Ghostty/iTerm2）
+/// 3. CGEvent Cmd+V — 最后兜底
+///
+/// 终端 App 跳过第一级（AX 写入会写到整个 buffer）
 enum TextInjector {
+
+    /// 终端类 App，AX 写入不可靠，直接走 clipboard
+    private static let terminalBundleIDs: Set<String> = [
+        "com.apple.Terminal",
+        "com.googlecode.iterm2",
+        "com.mitchellh.ghostty",
+    ]
+
+    static func isTerminalApp(_ bundleID: String) -> Bool {
+        terminalBundleIDs.contains(bundleID)
+    }
+
     @MainActor
     static func inject(text: String, to app: AppIdentity?) {
         guard !text.isEmpty else { return }
 
-        let pb = NSPasteboard.general
+        // 非终端 App：优先尝试 AX 直接插入
+        if let app, !terminalBundleIDs.contains(app.bundleID),
+           tryAXInsertion(text, pid: app.processID) {
+            Logger.log("Injector", "AX insert to \(app.bundleID)")
+            return
+        }
 
-        // 保存当前剪贴板
+        // Clipboard 注入（带 AX 菜单 fallback）
+        clipboardInject(text: text, app: app)
+    }
+
+    // MARK: - AX 直接插入
+
+    /// 通过 AX API 设置 kAXSelectedTextAttribute（在光标处插入）
+    private static func tryAXInsertion(_ text: String, pid: pid_t) -> Bool {
+        let appElement = AXUIElementCreateApplication(pid)
+
+        var focusedElement: AnyObject?
+        guard AXUIElementCopyAttributeValue(
+            appElement, kAXFocusedUIElementAttribute as CFString, &focusedElement
+        ) == .success else { return false }
+
+        let element = focusedElement as! AXUIElement
+
+        // 优先：kAXSelectedTextAttribute — 在光标处插入，不覆盖已有内容
+        if AXUIElementSetAttributeValue(
+            element, kAXSelectedTextAttribute as CFString, text as CFTypeRef
+        ) == .success {
+            return true
+        }
+
+        // 兜底：只在文本框为空时设置 kAXValueAttribute
+        var currentValue: AnyObject?
+        if AXUIElementCopyAttributeValue(element, kAXValueAttribute as CFString, &currentValue) == .success,
+           let currentText = currentValue as? String, !currentText.isEmpty {
+            return false  // 有内容，不覆盖
+        }
+
+        return AXUIElementSetAttributeValue(
+            element, kAXValueAttribute as CFString, text as CFTypeRef
+        ) == .success
+    }
+
+    // MARK: - Clipboard 注入
+
+    private static func clipboardInject(text: String, app: AppIdentity?) {
+        let pb = NSPasteboard.general
         let savedString = pb.string(forType: .string)
 
-        // 写入要注入的文字
         pb.clearContents()
         pb.setString(text, forType: .string)
+        let changeCountAfterPaste = pb.changeCount
 
-        // 模拟 Cmd+V 粘贴
+        // 优先：AX 菜单粘贴（绕过 Secure Keyboard Entry）
+        var pasted = false
+        if let pid = app?.processID {
+            pasted = triggerPasteViaMenu(pid: pid)
+        }
+
+        // 兜底：CGEvent Cmd+V
+        if !pasted {
+            simulateCmdV()
+        }
+
+        Logger.log("Injector", "Pasted to \(app?.bundleID ?? "unknown") via \(pasted ? "AX menu" : "CGEvent")")
+
+        // 延迟恢复剪贴板
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            if pb.changeCount == changeCountAfterPaste, let saved = savedString {
+                pb.clearContents()
+                pb.setString(saved, forType: .string)
+            }
+        }
+    }
+
+    /// 通过 AX 点击 Edit > Paste 菜单项
+    /// 绕过 Secure Keyboard Entry（Ghostty/iTerm2 开启时 CGEvent 被拦截）
+    private static func triggerPasteViaMenu(pid: pid_t) -> Bool {
+        let appElement = AXUIElementCreateApplication(pid)
+
+        var menuBarRef: AnyObject?
+        guard AXUIElementCopyAttributeValue(
+            appElement, kAXMenuBarAttribute as CFString, &menuBarRef
+        ) == .success else { return false }
+
+        var menuBarItems: AnyObject?
+        guard AXUIElementCopyAttributeValue(
+            menuBarRef as! AXUIElement, kAXChildrenAttribute as CFString, &menuBarItems
+        ) == .success, let topMenus = menuBarItems as? [AXUIElement] else { return false }
+
+        // 查找 Edit / 编辑 菜单
+        for topMenu in topMenus {
+            var title: AnyObject?
+            AXUIElementCopyAttributeValue(topMenu, kAXTitleAttribute as CFString, &title)
+            guard let menuTitle = title as? String,
+                  menuTitle == "Edit" || menuTitle == "编辑" else { continue }
+
+            var submenuRef: AnyObject?
+            guard AXUIElementCopyAttributeValue(
+                topMenu, kAXChildrenAttribute as CFString, &submenuRef
+            ) == .success,
+                  let submenus = submenuRef as? [AXUIElement],
+                  let editMenu = submenus.first else { continue }
+
+            var menuItems: AnyObject?
+            guard AXUIElementCopyAttributeValue(
+                editMenu, kAXChildrenAttribute as CFString, &menuItems
+            ) == .success, let items = menuItems as? [AXUIElement] else { continue }
+
+            for item in items {
+                var itemTitle: AnyObject?
+                AXUIElementCopyAttributeValue(item, kAXTitleAttribute as CFString, &itemTitle)
+                if let t = itemTitle as? String, t == "Paste" || t == "粘贴" || t == "貼上" {
+                    return AXUIElementPerformAction(item, kAXPressAction as CFString) == .success
+                }
+            }
+        }
+        return false
+    }
+
+    /// CGEvent Cmd+V 模拟
+    private static func simulateCmdV() {
         let source = CGEventSource(stateID: .hidSystemState)
         let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 0x09, keyDown: true)
         let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 0x09, keyDown: false)
@@ -25,16 +154,5 @@ enum TextInjector {
         keyUp?.flags = .maskCommand
         keyDown?.post(tap: .cghidEventTap)
         keyUp?.post(tap: .cghidEventTap)
-
-        Logger.log("Injector", "Pasted to \(app?.bundleID ?? "unknown")")
-
-        // 延迟恢复剪贴板
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            // 只在剪贴板没被其他操作修改时恢复
-            if pb.changeCount == pb.changeCount, let saved = savedString {
-                pb.clearContents()
-                pb.setString(saved, forType: .string)
-            }
-        }
     }
 }

--- a/scripts/we-shell-hook.zsh
+++ b/scripts/we-shell-hook.zsh
@@ -1,0 +1,95 @@
+#!/usr/bin/env zsh
+# WE 终端纠错 shell hook
+#
+# 安装方式：在 ~/.zshrc 中添加：
+#   source /path/to/we-shell-hook.zsh
+#
+# 工作原理：
+# 1. WE 向终端注入语音文本后，写 pending 文件到 ~/.we/pending-terminal.json
+# 2. 用户修正后按 Enter 执行命令
+# 3. zsh preexec hook 在命令执行前触发，读 pending → 对比实际命令 → 写 correction
+# 4. 下次 VoicePipeline 运行时导入 corrections
+
+__we_preexec() {
+    local pending_file="$HOME/.we/pending-terminal.json"
+    local corrections_file="$HOME/.we/terminal-corrections.jsonl"
+    local actual_command="$1"
+
+    [[ ! -f "$pending_file" ]] && return
+    [[ -z "$actual_command" ]] && return
+
+    # 用 Python 做对比和写入（JSON 处理更可靠）
+    python3 -c "
+import json, sys, os, time
+
+def main():
+    pending_path = '$pending_file'
+    corrections_path = '$corrections_file'
+    actual = '''$actual_command'''
+
+    try:
+        with open(pending_path) as f:
+            pending = json.load(f)
+    except:
+        return
+
+    inserted = pending.get('inserted_text', '')
+    if not inserted:
+        return
+
+    # 过期检查（>120 秒视为过期）
+    try:
+        from datetime import datetime
+        ts = datetime.fromisoformat(pending['timestamp'].replace('Z', '+00:00'))
+        age = (datetime.now(ts.tzinfo) - ts).total_seconds()
+        if age > 120:
+            os.remove(pending_path)
+            return
+    except:
+        pass
+
+    # 相似度检查
+    set_a, set_b = set(inserted), set(actual)
+    if not set_a or not set_b:
+        os.remove(pending_path)
+        return
+    intersection = len(set_a & set_b)
+    union = len(set_a | set_b)
+    sim = intersection / union if union > 0 else 0
+
+    ratio = len(actual) / max(len(inserted), 1)
+
+    # 完全相同 → 没修改
+    if sim >= 1.0 and ratio == 1.0:
+        os.remove(pending_path)
+        return
+
+    # 相似度过低 → 不是纠错
+    if sim < 0.3 or ratio < 0.3 or ratio > 3.0:
+        os.remove(pending_path)
+        return
+
+    quality = sim * min(ratio, 1.0 / ratio) if ratio != 0 else 0
+
+    correction = {
+        'inserted_text': inserted,
+        'raw_text': pending.get('raw_text', inserted),
+        'user_command': actual,
+        'quality': round(quality, 4),
+        'app_bundle_id': pending.get('app_bundle_id', ''),
+        'app_name': pending.get('app_name', ''),
+        'timestamp': pending.get('timestamp', '')
+    }
+
+    with open(corrections_path, 'a') as f:
+        f.write(json.dumps(correction, ensure_ascii=False) + '\n')
+
+    os.remove(pending_path)
+
+main()
+" 2>/dev/null
+}
+
+# 注册 zsh preexec hook
+autoload -Uz add-zsh-hook
+add-zsh-hook preexec __we_preexec


### PR DESCRIPTION
## Summary

基于在 Ghostty、微信、Telegram、Terminal、Claude Desktop、VS Code 等 App 中长期使用语音输入的实战经验，贡献三项工程优化。

### 1. CaptureProfile — per-app 纠错捕获策略

新增 `CaptureProfile.swift`，14 个常用 App 的独立配置：

| App 类型 | Submit Signal | Timeout | 示例 |
|----------|--------------|---------|------|
| IM | Enter | 15s | 微信、Telegram、Slack |
| 终端 | Enter (edit-detection) | 30s | Terminal、Ghostty、iTerm2 |
| IDE | Cmd+Enter | 30s | VS Code、Xcode |
| 笔记 | focusChange | 60s | Notes、TextEdit |
| 浏览器 | Enter | 30s | Safari、Chrome |

### 2. TextInjector — 三级 fallback + clipboard bug 修复

```
AX kAXSelectedTextAttribute → AX 菜单 Edit>Paste → CGEvent Cmd+V
```

- AX 直接插入：不动剪贴板，最干净（非终端 App 优先）
- AX 菜单粘贴：绕过 Secure Keyboard Entry（Ghostty/iTerm2 必需）
- CGEvent 模拟：最后兜底
- 修复 `pb.changeCount == pb.changeCount` 剪贴板恢复 bug (#1)

### 3. TerminalCorrectionBridge + zsh shell hook

解决终端纠错捕获的根本问题（Enter 后命令已提交，AX buffer 不可靠）：

```
WE 注入文本 → 写 ~/.we/pending-terminal.json
用户修正 + Enter → zsh preexec hook 对比 → 写 corrections
下次 VoicePipeline → 导入 corrections → L1 学习
```

Shell hook 安装：`source /path/to/scripts/we-shell-hook.zsh`

## 背景

这些都是实际使用几百次语音输入后踩过的坑：
- Ghostty 开启 Secure Keyboard Entry 后 CGEvent 粘贴静默失败
- 终端里 Enter 后 AX buffer 立刻混入命令输出，无法定位用户输入
- VS Code 里 Enter 只是换行，永远触发不了纠错对比
- 微信发送后文本框清空，需要保存 previousText

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)