### PR TITLE
Add real-time transcription display to recording indicator

### DIFF
--- a/client/Sources/AlternativesTest.swift
+++ b/client/Sources/AlternativesTest.swift
@@ -59,7 +59,7 @@ enum AlternativesTest {
                         guard result.isFinal else { continue }
 
                         let bestText = String(result.text.characters)
-                        let altCount = result.alternatives.count
+                        // let altCount = result.alternatives.count
 
                         // 提取词级置信度
                         typealias ConfKey = AttributeScopes.SpeechAttributes.ConfidenceAttribute

--- a/client/Sources/RecordingIndicator.swift
+++ b/client/Sources/RecordingIndicator.swift
@@ -1,26 +1,33 @@
 import AppKit
 
 /// 录音指示器：模仿 macOS 原生听写的浮动面板
-/// 深色毛玻璃背景 + 麦克风图标 + 脉冲动画 + 文字提示
+/// 深色毛玻璃背景 + 麦克风图标 + 脉冲动画 + 实时识别文字
 @MainActor
 final class RecordingIndicator {
+    enum State {
+        case listening
+        case processing
+    }
+
     private var window: NSWindow?
     private var pulseTimer: Timer?
     private var glowState = true
     private var indicatorView: RecordingPanelView?
+    private var baseOriginY: CGFloat = 0
 
     func show() {
         guard window == nil else { return }
 
-        let panelSize = NSSize(width: 160, height: 48)
+        let barSize = RecordingPanelView.barSize
         let screen = NSScreen.main ?? NSScreen.screens.first!
+        baseOriginY = screen.visibleFrame.minY + 80
         let origin = NSPoint(
-            x: screen.frame.midX - panelSize.width / 2,
-            y: screen.visibleFrame.minY + 80
+            x: screen.frame.midX - barSize.width / 2,
+            y: baseOriginY
         )
 
         let panel = NSPanel(
-            contentRect: NSRect(origin: origin, size: panelSize),
+            contentRect: NSRect(origin: origin, size: barSize),
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
@@ -33,13 +40,14 @@ final class RecordingIndicator {
         panel.ignoresMouseEvents = true
         panel.isMovableByWindowBackground = false
 
-        let view = RecordingPanelView(frame: NSRect(origin: .zero, size: panelSize))
+        let view = RecordingPanelView(frame: NSRect(origin: .zero, size: barSize))
         panel.contentView = view
         self.indicatorView = view
 
         panel.orderFrontRegardless()
         self.window = panel
 
+        setState(.listening)
         startPulse()
         Logger.log("UI", "Recording indicator shown")
     }
@@ -53,8 +61,35 @@ final class RecordingIndicator {
         Logger.log("UI", "Recording indicator hidden")
     }
 
+    func updateText(_ text: String) {
+        guard let view = indicatorView, let panel = window else { return }
+        let newSize = view.updateTranscription(text)
+        let screen = NSScreen.main ?? NSScreen.screens.first!
+        let newOrigin = NSPoint(
+            x: screen.frame.midX - newSize.width / 2,
+            y: baseOriginY
+        )
+        panel.setFrame(NSRect(origin: newOrigin, size: newSize), display: true)
+    }
+
+    func setState(_ state: State) {
+        guard let view = indicatorView else { return }
+        switch state {
+        case .listening:
+            view.setState(text: "正在聆听…", color: .systemRed, showsLoading: false)
+            startPulse()
+        case .processing:
+            pulseTimer?.invalidate()
+            pulseTimer = nil
+            view.setState(text: "正在处理…", color: .systemOrange, showsLoading: true)
+            view.setPulse(false)
+        }
+    }
+
     private func startPulse() {
+        pulseTimer?.invalidate()
         glowState = true
+        indicatorView?.setPulse(true)
         pulseTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [weak self] _ in
             MainActor.assumeIsolated {
                 guard let self else { return }
@@ -68,12 +103,25 @@ final class RecordingIndicator {
 // MARK: - 面板视图
 
 private class RecordingPanelView: NSView {
+    static let barSize = NSSize(width: 160, height: 48)
+    private static let textMaxWidth: CGFloat = 400
+    private static let textPadding: CGFloat = 12
+
     private let blurView: NSVisualEffectView
     private let dotLayer = CAShapeLayer()
+    private let micView: NSImageView
+    private let loadingIndicator: NSProgressIndicator
+    private let statusLabel: NSTextField
+    private let transcriptionLabel: NSTextField
     private var pulsing = true
 
     override init(frame: NSRect) {
         blurView = NSVisualEffectView(frame: NSRect(origin: .zero, size: frame.size))
+        micView = NSImageView(frame: NSRect(x: 34, y: (Self.barSize.height - 22) / 2, width: 22, height: 22))
+        loadingIndicator = NSProgressIndicator(frame: NSRect(x: 35, y: (Self.barSize.height - 16) / 2, width: 16, height: 16))
+        statusLabel = NSTextField(labelWithString: "正在聆听…")
+        transcriptionLabel = NSTextField(wrappingLabelWithString: "")
+
         super.init(frame: frame)
 
         wantsLayer = true
@@ -89,14 +137,12 @@ private class RecordingPanelView: NSView {
 
         // 红色脉冲圆点
         let dotSize: CGFloat = 10
-        let dotRect = CGRect(x: 16, y: (frame.height - dotSize) / 2, width: dotSize, height: dotSize)
         dotLayer.path = CGPath(ellipseIn: CGRect(origin: .zero, size: CGSize(width: dotSize, height: dotSize)), transform: nil)
         dotLayer.fillColor = NSColor.systemRed.cgColor
-        dotLayer.frame = dotRect
+        dotLayer.frame = CGRect(x: 16, y: (Self.barSize.height - dotSize) / 2, width: dotSize, height: dotSize)
         layer?.addSublayer(dotLayer)
 
         // 麦克风图标
-        let micView = NSImageView(frame: NSRect(x: 34, y: (frame.height - 22) / 2, width: 22, height: 22))
         if let micImage = NSImage(systemSymbolName: "mic.fill", accessibilityDescription: nil) {
             let config = NSImage.SymbolConfiguration(pointSize: 15, weight: .medium)
             micView.image = micImage.withSymbolConfiguration(config)
@@ -104,12 +150,31 @@ private class RecordingPanelView: NSView {
         }
         addSubview(micView)
 
-        // 文字
-        let label = NSTextField(labelWithString: "正在聆听…")
-        label.font = .systemFont(ofSize: 13, weight: .medium)
-        label.textColor = .white
-        label.frame = NSRect(x: 60, y: (frame.height - 18) / 2, width: 90, height: 18)
-        addSubview(label)
+        loadingIndicator.style = .spinning
+        loadingIndicator.controlSize = .small
+        loadingIndicator.isDisplayedWhenStopped = false
+        loadingIndicator.isIndeterminate = true
+        loadingIndicator.appearance = NSAppearance(named: .darkAqua)
+        loadingIndicator.stopAnimation(nil)
+        addSubview(loadingIndicator)
+
+        // 状态文字
+        statusLabel.font = .systemFont(ofSize: 13, weight: .medium)
+        statusLabel.textColor = .white
+        statusLabel.frame = NSRect(x: 60, y: (Self.barSize.height - 18) / 2, width: 90, height: 18)
+        addSubview(statusLabel)
+
+        // 实时识别文字（初始隐藏，有内容时显示在栏上方）
+        transcriptionLabel.font = .systemFont(ofSize: 13)
+        transcriptionLabel.textColor = .white.withAlphaComponent(0.9)
+        transcriptionLabel.backgroundColor = .clear
+        transcriptionLabel.isEditable = false
+        transcriptionLabel.isBordered = false
+        transcriptionLabel.isHidden = true
+        transcriptionLabel.maximumNumberOfLines = 0
+        transcriptionLabel.cell?.lineBreakMode = .byCharWrapping
+        transcriptionLabel.preferredMaxLayoutWidth = Self.textMaxWidth - Self.textPadding * 2
+        addSubview(transcriptionLabel)
     }
 
     required init?(coder: NSCoder) { nil }
@@ -117,5 +182,55 @@ private class RecordingPanelView: NSView {
     func setPulse(_ on: Bool) {
         pulsing = on
         dotLayer.opacity = on ? 1.0 : 0.3
+    }
+
+    func setState(text: String, color: NSColor, showsLoading: Bool) {
+        statusLabel.stringValue = text
+        dotLayer.fillColor = color.cgColor
+        micView.isHidden = showsLoading
+        loadingIndicator.isHidden = !showsLoading
+        if showsLoading {
+            loadingIndicator.startAnimation(nil)
+        } else {
+            loadingIndicator.stopAnimation(nil)
+        }
+    }
+
+    /// 更新识别文字，返回面板所需的新尺寸
+    func updateTranscription(_ text: String) -> NSSize {
+        let hasText = !text.isEmpty
+        transcriptionLabel.isHidden = !hasText
+        transcriptionLabel.stringValue = text
+
+        guard hasText else {
+            frame.size = Self.barSize
+            blurView.frame = bounds
+            return Self.barSize
+        }
+
+        let textWidth = Self.textMaxWidth - Self.textPadding * 2
+        let textHeight = textHeightFor(text, width: textWidth)
+        let totalHeight = Self.barSize.height + textHeight + Self.textPadding * 2
+        let size = NSSize(width: Self.textMaxWidth, height: totalHeight)
+
+        frame.size = size
+        blurView.frame = bounds
+        transcriptionLabel.frame = NSRect(
+            x: Self.textPadding,
+            y: Self.barSize.height + Self.textPadding,
+            width: textWidth,
+            height: textHeight
+        )
+        return size
+    }
+
+    private func textHeightFor(_ text: String, width: CGFloat) -> CGFloat {
+        let attrs: [NSAttributedString.Key: Any] = [.font: transcriptionLabel.font!]
+        let rect = (text as NSString).boundingRect(
+            with: NSSize(width: width, height: .greatestFiniteMagnitude),
+            options: [.usesLineFragmentOrigin, .usesFontLeading],
+            attributes: attrs
+        )
+        return ceil(rect.height)
     }
 }

--- a/client/Sources/VoiceModule.swift
+++ b/client/Sources/VoiceModule.swift
@@ -20,6 +20,9 @@ final class VoiceModule: WEModule {
     /// 状态变化回调（UI 指示器用）
     var onStateChange: ((State) -> Void)?
 
+    /// 实时识别文字回调（UI 指示器展示用）
+    var onPartialText: ((String) -> Void)?
+
     private var session: VoiceSession?
     private let pipeline = VoicePipeline()
     private var pinnedApp: AppIdentity?
@@ -55,6 +58,9 @@ final class VoiceModule: WEModule {
         Logger.log("Voice", "Pinned app: \(pinnedApp?.bundleID ?? "unknown")")
 
         let voiceSession = VoiceSession()
+        voiceSession.onPartialResult = { [weak self] text in
+            self?.onPartialText?(text)
+        }
         self.session = voiceSession
         self.screenContext = nil
 

--- a/client/Sources/VoiceSession.swift
+++ b/client/Sources/VoiceSession.swift
@@ -48,7 +48,6 @@ final class VoiceSession {
     private var finalizedText = ""
     private var volatileText = ""
     private var allWords: [WordInfo] = []
-    /// 整句级 alternatives 累积（每个 final segment 的所有候选）
     private var allAlternatives: [[String]] = []
 
     /// 识别完成时的回调
@@ -78,6 +77,7 @@ final class VoiceSession {
         finalizedText = ""
         volatileText = ""
         allWords = []
+        allAlternatives = []
 
         // 1. 查找最佳中文 locale
         let bestLocale = await findChineseLocale()
@@ -86,12 +86,13 @@ final class VoiceSession {
         }
         Logger.log("Voice", "Using locale: \(bestLocale.identifier(.bcp47))")
 
-        // 2. 配置 SpeechTranscriber（含 volatile + alternatives）
+        // 2. 配置 SpeechTranscriber
+        // 采用 Apple 官方 progressive live preset：
+        // fastResults + volatileResults + audioTimeRange
+        // 先优先保证低延迟流式输出，放弃对 live 路径非关键的 confidence 属性。
         let transcriber = SpeechTranscriber(
             locale: bestLocale,
-            transcriptionOptions: [],
-            reportingOptions: [.volatileResults, .alternativeTranscriptions],
-            attributeOptions: [.audioTimeRange, .transcriptionConfidence]
+            preset: .timeIndexedProgressiveTranscription
         )
         self.transcriber = transcriber
 
@@ -111,10 +112,7 @@ final class VoiceSession {
         let (inputSequence, inputBuilder) = AsyncStream<AnalyzerInput>.makeStream()
         self.inputBuilder = inputBuilder
 
-        // 6. 启动分析器
-        try await analyzer.start(inputSequence: inputSequence)
-
-        // 7. 启动结果处理任务
+        // 6. 先启动结果处理（确保在分析开始前就准备好接收）
         resultTask = Task { [weak self] in
             do {
                 for try await result in transcriber.results {
@@ -124,11 +122,11 @@ final class VoiceSession {
                     if result.isFinal {
                         self.finalizedText += text
                         self.volatileText = ""
+                        self.onPartialResult?(self.finalizedText)
 
                         let words = self.extractWords(from: result.text)
                         self.allWords.append(contentsOf: words)
 
-                        // 收集整句级 alternatives
                         let alts = result.alternatives.map { String($0.characters) }
                         self.allAlternatives.append(alts)
 
@@ -148,6 +146,9 @@ final class VoiceSession {
                 Logger.log("Voice", "Result stream error: \(error)")
             }
         }
+
+        // 7. 启动实时分析（立即返回，结果实时流出到 resultTask）
+        try await analyzer.start(inputSequence: inputSequence)
 
         // 8. 准备音频文件
         let fileName = ISO8601DateFormatter().string(from: Date()).replacingOccurrences(of: ":", with: "-")
@@ -212,11 +213,11 @@ final class VoiceSession {
         captureDelegate?.close()
         captureDelegate = nil
 
-        // 告诉分析器音频结束
+        // 结束输入流 → analyzeSequence 返回
         inputBuilder?.finish()
-        Logger.log("Voice", "Input stream finished, waiting for analyzer...")
+        Logger.log("Voice", "Input stream finished, finalizing...")
 
-        // 等待分析器完成（带超时）
+        // 最终化分析结果
         do {
             try await withThrowingTimeout(seconds: 5) {
                 try await self.analyzer?.finalizeAndFinishThroughEndOfInput()
@@ -226,12 +227,12 @@ final class VoiceSession {
             Logger.log("Voice", "Finalize timeout/error: \(error)")
         }
 
-        // 给 resultTask 短暂时间处理最终结果，然后强制取消
+        // 给 resultTask 短暂时间处理最终结果
         Logger.log("Voice", "Waiting briefly for results...")
         try? await Task.sleep(for: .milliseconds(500))
         resultTask?.cancel()
         resultTask = nil
-        Logger.log("Voice", "Result task cancelled")
+        Logger.log("Voice", "Result task done")
 
         let fullText = finalizedText + volatileText
         isRunning = false

--- a/client/Sources/WEApp.swift
+++ b/client/Sources/WEApp.swift
@@ -169,7 +169,7 @@ enum MeetingBenchmark {
     }
 
     static func formatResult(_ result: MeetingResult, totalTime: Double, mdPath: String?) -> [String: Any] {
-        var json: [String: Any] = [
+        let json: [String: Any] = [
             "audio": result.audioPath ?? "",
             "duration_s": round(result.duration * 100) / 100,
             "total_processing_s": round(totalTime * 100) / 100,
@@ -220,13 +220,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let voiceModule = VoiceModule()
         voiceModule.onStateChange = { [weak self] state in
             guard let self else { return }
-            let recording = state == .recording
-            self.statusBar?.setRecording(recording)
-            if recording {
+            self.statusBar?.setRecording(state == .recording)
+            switch state {
+            case .recording:
                 self.recordingIndicator.show()
-            } else {
+                self.recordingIndicator.setState(.listening)
+            case .idle:
                 self.recordingIndicator.hide()
+            case .processing:
+                self.recordingIndicator.setState(.processing)
             }
+        }
+        voiceModule.onPartialText = { [weak self] text in
+            self?.recordingIndicator.updateText(text)
         }
         moduleManager.register(voiceModule)
 


### PR DESCRIPTION
Use streaming start(inputSequence:) instead of batch analyzeSequence for live results. RecordingIndicator now shows volatile text during recording with listening/processing state transitions.