### PR TITLE
feat(meeting): capture system audio for online meetings (Zoom/腾讯会议/飞书)

### DIFF
--- a/client/Sources/MeetingSession.swift
+++ b/client/Sources/MeetingSession.swift
@@ -3,10 +3,33 @@ import CoreMedia
 import FluidAudio
 import Speech
 
+// MARK: - 音频采集模式
+
+/// 会议模式下的音频来源选择
+enum AudioSourceMode: String {
+    /// 仅麦克风（默认，兼容旧行为）
+    case mic
+    /// 仅系统音频输出（Zoom/腾讯会议远端声音），需要屏幕录制权限
+    case system
+    /// 麦克风 + 系统音频混合（推荐用于线上会议）
+    case both
+
+    init(configValue: String?) {
+        switch configValue?.lowercased() {
+        case "system": self = .system
+        case "both":   self = .both
+        default:       self = .mic
+        }
+    }
+
+    var needsMicrophone: Bool { self == .mic || self == .both }
+    var needsSystemAudio: Bool { self == .system || self == .both }
+}
+
 // MARK: - 会议录音会话
 
 /// 长时间会议录音，支持连续转写 + 批量说话人分离
-/// 音频采集复用 VoiceSession 的 AVCaptureSession 方案（兼容蓝牙设备）
+/// 音频采集支持三种模式：仅麦克风 / 仅系统音频（ScreenCaptureKit）/ 两者混合
 /// 转写用 SpeechAnalyzer 实时流式处理，分离在录音结束后批量执行
 @MainActor
 final class MeetingSession {
@@ -29,6 +52,9 @@ final class MeetingSession {
 
     private var captureSession: AVCaptureSession?
     private var captureDelegate: MeetingCaptureDelegate?
+    private var systemAudioCapture: SystemAudioCapture?
+    private var mixer: AudioMixer?
+    private var audioMode: AudioSourceMode = .mic
 
     // MARK: - SpeechAnalyzer 转写
 
@@ -218,12 +244,19 @@ final class MeetingSession {
         }
     }
 
-    // MARK: - 麦克风启动（正常使用）
+    // MARK: - 启动（正常使用）
 
     func start() async throws {
         guard !isRunning else { return }
 
-        guard VoiceSession.isAuthorized else {
+        // 读取音频来源模式（mic / system / both），默认 mic 兼容旧行为
+        let mode = AudioSourceMode(
+            configValue: RuntimeConfig.shared.meetingConfig["audio_source"] as? String
+        )
+        audioMode = mode
+        Logger.log("Meeting", "Audio source mode: \(mode.rawValue)")
+
+        if mode.needsMicrophone, !VoiceSession.isAuthorized {
             throw VoiceError.notAuthorized
         }
 
@@ -303,25 +336,19 @@ final class MeetingSession {
         let url = WEDataDir.url.appendingPathComponent("audio/\(fileName).wav")
         audioFileURL = url
 
-        // 9. 启动 AVCaptureSession
-        guard let audioDevice = AVCaptureDevice.default(for: .audio) else {
-            throw VoiceError.noAudioDevice
-        }
-        Logger.log("Meeting", "Audio device: \(audioDevice.localizedName)")
+        // 9. 配置音频采集（按模式分支）
 
-        let session = AVCaptureSession()
-        let deviceInput = try AVCaptureDeviceInput(device: audioDevice)
-        session.addInput(deviceInput)
+        // 仅在 .both 模式下需要混合器：麦克风做主时钟，系统音频样本从队列中弹出求和
+        let mixer: AudioMixer? = (mode == .both) ? AudioMixer() : nil
+        self.mixer = mixer
 
-        let audioOutput = AVCaptureAudioDataOutput()
-        let captureQueue = DispatchQueue(label: "com.antigravity.we.meeting-capture")
-
-        // 创建 delegate，分叉音频到转写 + 分离缓冲
+        // 创建共享的 delegate（送 SpeechAnalyzer + 分离 + WAV 文件）
         let delegate = MeetingCaptureDelegate(
             inputBuilder: inputBuilder,
             analyzerFormat: analyzerFormat,
             audioFileURL: url,
             diarizationSampleRate: diarizationSampleRate,
+            mixer: mixer,
             onDiarizationSamples: { [weak self] samples in
                 // 回调在后台队列，通过 DispatchQueue.main 桥接到 MainActor
                 DispatchQueue.main.async {
@@ -329,13 +356,60 @@ final class MeetingSession {
                 }
             }
         )
-        audioOutput.setSampleBufferDelegate(delegate, queue: captureQueue)
-        session.addOutput(audioOutput)
-
         self.captureDelegate = delegate
-        self.captureSession = session
 
-        session.startRunning()
+        // 9a. 麦克风采集（.mic / .both）
+        if mode.needsMicrophone {
+            guard let audioDevice = AVCaptureDevice.default(for: .audio) else {
+                throw VoiceError.noAudioDevice
+            }
+            Logger.log("Meeting", "Audio device: \(audioDevice.localizedName)")
+
+            let session = AVCaptureSession()
+            let deviceInput = try AVCaptureDeviceInput(device: audioDevice)
+            session.addInput(deviceInput)
+
+            let audioOutput = AVCaptureAudioDataOutput()
+            let captureQueue = DispatchQueue(label: "com.antigravity.we.meeting-capture")
+            audioOutput.setSampleBufferDelegate(delegate, queue: captureQueue)
+            session.addOutput(audioOutput)
+
+            session.startRunning()
+            self.captureSession = session
+        }
+
+        // 9b. 系统音频采集（.system / .both）
+        if mode.needsSystemAudio {
+            let systemCapture = SystemAudioCapture()
+            self.systemAudioCapture = systemCapture
+
+            if mode == .system {
+                // 仅系统音频：直接喂给 delegate 走完整 SA + WAV + 分离流程
+                systemCapture.onSampleBuffer = { [weak delegate] buffer in
+                    delegate?.handleSystemSampleBuffer(buffer)
+                }
+            } else {
+                // .both：系统音频转为 16kHz Float32 mono 后推入混合器队列
+                let sysConverter = MonoFloat32Converter(targetSampleRate: diarizationSampleRate)
+                systemCapture.onSampleBuffer = { [weak mixer] buffer in
+                    guard let mixer, let samples = sysConverter.convert(buffer) else { return }
+                    mixer.pushSystemSamples(samples)
+                }
+            }
+
+            do {
+                try await systemCapture.start()
+            } catch {
+                Logger.log("Meeting", "System audio capture failed: \(error)")
+                // 系统音频不可用时的降级策略：.system 直接抛出；.both 降级为仅 mic
+                if mode == .system {
+                    throw error
+                }
+                self.systemAudioCapture = nil
+                self.mixer = nil
+            }
+        }
+
         isRunning = true
         startDate = Date()
 
@@ -370,6 +444,12 @@ final class MeetingSession {
         // 停止音频采集
         captureSession?.stopRunning()
         captureSession = nil
+        if let systemAudioCapture {
+            await systemAudioCapture.stop()
+        }
+        systemAudioCapture = nil
+        mixer?.drain()
+        mixer = nil
         captureDelegate?.close()
         captureDelegate = nil
 
@@ -584,22 +664,27 @@ final class MeetingSession {
 
 // MARK: - 会议音频采集代理
 
-/// 从 AVCaptureSession 接收音频，分叉到：
+/// 从音频源（AVCaptureSession 麦克风 / SCStream 系统音频）接收音频，分叉到：
 /// 1. SpeechAnalyzer（实时转写）
 /// 2. diarization buffer（16kHz Float32 mono 累积）
 /// 3. WAV 文件（持久化）
+///
+/// 当 mixer != nil 时（.both 模式），每个输入 buffer 会与 mixer 中已入队的系统音频
+/// 样本做逐样本相加，再走后续三条分支。麦克风作为主时钟驱动输出节奏。
 final class MeetingCaptureDelegate: NSObject, AVCaptureAudioDataOutputSampleBufferDelegate, @unchecked Sendable {
     private let inputBuilder: AsyncStream<AnalyzerInput>.Continuation
     private let analyzerFormat: AVAudioFormat?
     private let audioFileURL: URL
     private let diarizationSampleRate: Int
     private let onDiarizationSamples: ([Float]) -> Void
+    private let mixer: AudioMixer?
 
     // 格式转换器
     private var analyzerConverter: AVAudioConverter?
     private var diarizationConverter: AVAudioConverter?
+    private var mixerInputConverter: AVAudioConverter?
 
-    // 分离目标格式：16kHz Float32 mono
+    // 分离目标格式：16kHz Float32 mono（.both 模式下也用作混合的中间格式）
     private lazy var diarizationFormat: AVAudioFormat? = {
         AVAudioFormat(
             commonFormat: .pcmFormatFloat32,
@@ -621,12 +706,14 @@ final class MeetingCaptureDelegate: NSObject, AVCaptureAudioDataOutputSampleBuff
         analyzerFormat: AVAudioFormat?,
         audioFileURL: URL,
         diarizationSampleRate: Int,
+        mixer: AudioMixer? = nil,
         onDiarizationSamples: @escaping ([Float]) -> Void
     ) {
         self.inputBuilder = inputBuilder
         self.analyzerFormat = analyzerFormat
         self.audioFileURL = audioFileURL.deletingPathExtension().appendingPathExtension("wav")
         self.diarizationSampleRate = diarizationSampleRate
+        self.mixer = mixer
         self.onDiarizationSamples = onDiarizationSamples
         super.init()
     }
@@ -635,10 +722,19 @@ final class MeetingCaptureDelegate: NSObject, AVCaptureAudioDataOutputSampleBuff
         finalizeWAV()
     }
 
+    // AVCaptureSession 麦克风路径
     func captureOutput(_ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
+        handleSampleBuffer(sampleBuffer)
+    }
+
+    /// 由 SystemAudioCapture 直接调用（.system 模式下无 AVCaptureSession）
+    func handleSystemSampleBuffer(_ sampleBuffer: CMSampleBuffer) {
+        handleSampleBuffer(sampleBuffer)
+    }
+
+    private func handleSampleBuffer(_ sampleBuffer: CMSampleBuffer) {
         bufferCount += 1
 
-        // CMSampleBuffer → AVAudioPCMBuffer（复用 VoiceSession 的扩展方法）
         guard let pcmBuffer = sampleBuffer.toPCMBuffer() else {
             if bufferCount <= 3 { Logger.log("Meeting", "Audio #\(bufferCount): CMSampleBuffer conversion failed") }
             return
@@ -648,24 +744,36 @@ final class MeetingCaptureDelegate: NSObject, AVCaptureAudioDataOutputSampleBuff
             Logger.log("Meeting", "Audio #\(bufferCount): \(pcmBuffer.frameLength) frames, fmt=\(pcmBuffer.format)")
         }
 
+        // .both 模式：先把当前 buffer（麦克风）与 mixer 中的系统音频样本相加
+        let processedBuffer: AVAudioPCMBuffer
+        if let mixer {
+            guard let mixed = mixWithSystemAudio(micBuffer: pcmBuffer, mixer: mixer) else {
+                return
+            }
+            processedBuffer = mixed
+        } else {
+            processedBuffer = pcmBuffer
+        }
+
         // --- 分支1: 送 SpeechAnalyzer（可能需要格式转换）---
         let analyzerBuffer: AVAudioPCMBuffer
         if let targetFormat = analyzerFormat,
-           pcmBuffer.format.sampleRate != targetFormat.sampleRate
-            || pcmBuffer.format.commonFormat != targetFormat.commonFormat {
+           processedBuffer.format.sampleRate != targetFormat.sampleRate
+            || processedBuffer.format.commonFormat != targetFormat.commonFormat
+            || processedBuffer.format.channelCount != targetFormat.channelCount {
 
             if analyzerConverter == nil {
-                analyzerConverter = AVAudioConverter(from: pcmBuffer.format, to: targetFormat)
-                Logger.log("Meeting", "Analyzer converter: \(pcmBuffer.format) → \(targetFormat)")
+                analyzerConverter = AVAudioConverter(from: processedBuffer.format, to: targetFormat)
+                Logger.log("Meeting", "Analyzer converter: \(processedBuffer.format) → \(targetFormat)")
             }
             guard let converter = analyzerConverter,
-                  let converted = convert(buffer: pcmBuffer, using: converter, to: targetFormat) else {
+                  let converted = convert(buffer: processedBuffer, using: converter, to: targetFormat) else {
                 if bufferCount <= 3 { Logger.log("Meeting", "Audio #\(bufferCount): analyzer conversion failed") }
                 return
             }
             analyzerBuffer = converted
         } else {
-            analyzerBuffer = pcmBuffer
+            analyzerBuffer = processedBuffer
         }
 
         // 送 SpeechAnalyzer
@@ -678,21 +786,21 @@ final class MeetingCaptureDelegate: NSObject, AVCaptureAudioDataOutputSampleBuff
         // --- 分支2: 送分离缓冲区（16kHz Float32 mono）---
         if let diaFmt = diarizationFormat {
             let diaBuffer: AVAudioPCMBuffer
-            if pcmBuffer.format.sampleRate != diaFmt.sampleRate
-                || pcmBuffer.format.commonFormat != diaFmt.commonFormat
-                || pcmBuffer.format.channelCount != diaFmt.channelCount {
+            if processedBuffer.format.sampleRate != diaFmt.sampleRate
+                || processedBuffer.format.commonFormat != diaFmt.commonFormat
+                || processedBuffer.format.channelCount != diaFmt.channelCount {
 
                 if diarizationConverter == nil {
-                    diarizationConverter = AVAudioConverter(from: pcmBuffer.format, to: diaFmt)
-                    Logger.log("Meeting", "Diarization converter: \(pcmBuffer.format) → \(diaFmt)")
+                    diarizationConverter = AVAudioConverter(from: processedBuffer.format, to: diaFmt)
+                    Logger.log("Meeting", "Diarization converter: \(processedBuffer.format) → \(diaFmt)")
                 }
                 guard let converter = diarizationConverter,
-                      let converted = convert(buffer: pcmBuffer, using: converter, to: diaFmt) else {
+                      let converted = convert(buffer: processedBuffer, using: converter, to: diaFmt) else {
                     return
                 }
                 diaBuffer = converted
             } else {
-                diaBuffer = pcmBuffer
+                diaBuffer = processedBuffer
             }
 
             // 提取 Float32 样本
@@ -702,6 +810,55 @@ final class MeetingCaptureDelegate: NSObject, AVCaptureAudioDataOutputSampleBuff
                 onDiarizationSamples(samples)
             }
         }
+    }
+
+    /// 把麦克风 buffer 转到 16kHz Float32 mono，与 mixer 中等量系统样本逐样本相加
+    /// 返回的 buffer 格式为 diarizationFormat（16kHz Float32 mono）
+    private func mixWithSystemAudio(micBuffer: AVAudioPCMBuffer, mixer: AudioMixer) -> AVAudioPCMBuffer? {
+        guard let diaFmt = diarizationFormat else { return micBuffer }
+
+        // 1. 把麦克风 buffer 转为 16kHz Float32 mono
+        let micMono: AVAudioPCMBuffer
+        if micBuffer.format.sampleRate == diaFmt.sampleRate
+            && micBuffer.format.commonFormat == diaFmt.commonFormat
+            && micBuffer.format.channelCount == diaFmt.channelCount {
+            micMono = micBuffer
+        } else {
+            if mixerInputConverter == nil {
+                mixerInputConverter = AVAudioConverter(from: micBuffer.format, to: diaFmt)
+                Logger.log("Meeting", "Mixer mic converter: \(micBuffer.format) → \(diaFmt)")
+            }
+            guard let converter = mixerInputConverter,
+                  let converted = convert(buffer: micBuffer, using: converter, to: diaFmt) else {
+                return nil
+            }
+            micMono = converted
+        }
+
+        let count = Int(micMono.frameLength)
+        guard count > 0, let micData = micMono.floatChannelData?[0] else {
+            return micMono
+        }
+
+        // 2. 从 mixer 取等量系统样本（不足补 0）
+        let sysSamples = mixer.popSystemSamples(count: count)
+
+        // 3. 求和并硬限幅到 [-1, 1]
+        guard let mixed = AVAudioPCMBuffer(pcmFormat: diaFmt, frameCapacity: AVAudioFrameCount(count)),
+              let mixedData = mixed.floatChannelData?[0] else {
+            return micMono
+        }
+        mixed.frameLength = AVAudioFrameCount(count)
+
+        sysSamples.withUnsafeBufferPointer { sysPtr in
+            guard let sysBase = sysPtr.baseAddress else { return }
+            for i in 0..<count {
+                let sum = micData[i] + sysBase[i]
+                mixedData[i] = max(-1.0, min(1.0, sum))
+            }
+        }
+
+        return mixed
     }
 
     // MARK: - WAV 手动写入

--- a/client/Sources/RuntimeConfig.swift
+++ b/client/Sources/RuntimeConfig.swift
@@ -35,6 +35,15 @@ final class RuntimeConfig {
         values["remote"] as? [String: Any] ?? [:]
     }
 
+    /// 会议模式配置
+    /// audio_source: "mic"（默认）| "system" | "both"
+    ///   - mic: 仅麦克风（当前行为，兼容在线会议中自己这一侧的声音）
+    ///   - system: 仅系统输出（腾讯会议/Zoom 对方的声音；需要屏幕录制权限）
+    ///   - both: 麦克风 + 系统音频混合（推荐用于线上会议）
+    var meetingConfig: [String: Any] {
+        values["meeting"] as? [String: Any] ?? [:]
+    }
+
     private init() {
         self.configURL = WEDataDir.url.appendingPathComponent("config.json")
         load()
@@ -66,6 +75,9 @@ final class RuntimeConfig {
                     "enabled": false,
                     "server": "",
                     "remote_dir": "~/we-data"
+                ],
+                "meeting": [
+                    "audio_source": "mic"
                 ],
                 "downloads": [:],
                 "remote": [

--- a/client/Sources/SystemAudioCapture.swift
+++ b/client/Sources/SystemAudioCapture.swift
@@ -1,0 +1,199 @@
+import AVFoundation
+import CoreMedia
+import ScreenCaptureKit
+
+// MARK: - 系统音频采集
+
+/// 通过 ScreenCaptureKit 采集系统音频输出（Zoom / 腾讯会议 / 飞书等会议软件远端的声音）
+///
+/// 输出与 AVCaptureSession 一致的 CMSampleBuffer，交由调用方消费。
+/// 需要用户授予「屏幕录制」权限，首次使用时系统会弹出授权。
+///
+/// SCK 技术细节：
+/// - 必须提供 display filter 和非零视频尺寸，因此配置 2×2 最小画面并丢弃视频输出
+/// - excludesCurrentProcessAudio = true 避免 WE 自身产生的声音被循环录制
+@MainActor
+final class SystemAudioCapture: NSObject, SCStreamDelegate {
+    private var stream: SCStream?
+    private var audioOutput: SystemAudioOutput?
+    private let captureQueue = DispatchQueue(label: "com.antigravity.we.system-audio-capture")
+
+    /// 每个音频 sample buffer 到达时的回调（在 captureQueue 后台队列执行）
+    var onSampleBuffer: ((CMSampleBuffer) -> Void)?
+
+    func start() async throws {
+        let content = try await SCShareableContent.excludingDesktopWindows(
+            false, onScreenWindowsOnly: true
+        )
+        guard let display = content.displays.first else {
+            Logger.log("SystemAudio", "No display found")
+            throw VoiceError.noAudioDevice
+        }
+
+        let filter = SCContentFilter(display: display, excludingWindows: [])
+
+        let config = SCStreamConfiguration()
+        config.capturesAudio = true
+        config.excludesCurrentProcessAudio = true
+        config.sampleRate = 48000
+        config.channelCount = 2
+        config.width = 2
+        config.height = 2
+        config.minimumFrameInterval = CMTime(value: 1, timescale: 1)
+        config.queueDepth = 5
+
+        let stream = SCStream(filter: filter, configuration: config, delegate: self)
+        let audioOutput = SystemAudioOutput { [weak self] buffer in
+            self?.onSampleBuffer?(buffer)
+        }
+        try stream.addStreamOutput(audioOutput, type: .audio, sampleHandlerQueue: captureQueue)
+
+        try await stream.startCapture()
+
+        self.stream = stream
+        self.audioOutput = audioOutput
+        Logger.log("SystemAudio", "Started (\(Int(config.sampleRate))Hz, \(config.channelCount)ch)")
+    }
+
+    func stop() async {
+        guard let stream else { return }
+        do {
+            try await stream.stopCapture()
+            Logger.log("SystemAudio", "Stopped")
+        } catch {
+            Logger.log("SystemAudio", "Stop error: \(error)")
+        }
+        self.stream = nil
+        self.audioOutput = nil
+    }
+
+    // MARK: - SCStreamDelegate
+
+    nonisolated func stream(_ stream: SCStream, didStopWithError error: Error) {
+        Logger.log("SystemAudio", "Stream stopped with error: \(error)")
+    }
+}
+
+/// SCStreamOutput 包装，只处理音频 buffer
+private final class SystemAudioOutput: NSObject, SCStreamOutput {
+    private let handler: (CMSampleBuffer) -> Void
+
+    init(handler: @escaping (CMSampleBuffer) -> Void) {
+        self.handler = handler
+        super.init()
+    }
+
+    func stream(_ stream: SCStream, didOutputSampleBuffer sampleBuffer: CMSampleBuffer, of type: SCStreamOutputType) {
+        guard type == .audio,
+              sampleBuffer.isValid,
+              CMSampleBufferGetNumSamples(sampleBuffer) > 0 else {
+            return
+        }
+        handler(sampleBuffer)
+    }
+}
+
+// MARK: - 音频混合器
+
+/// 麦克风 + 系统音频的简单混合器
+///
+/// 设计：麦克风作为主时钟，系统音频以 16kHz Float32 mono 的样本流形式累积在队列中。
+/// 每次麦克风产生 N 帧时，从系统队列弹出等长的样本并与麦克风逐样本相加。
+/// 若系统队列样本不足，缺口用 0 填充（即视为静音）。
+///
+/// 这个设计避开了 CMSampleBuffer PTS 对齐的复杂性，代价是系统和麦克风之间可能有
+/// 最多 ~100ms 的相对延迟。对会议转写场景足够。
+final class AudioMixer: @unchecked Sendable {
+    private let lock = NSLock()
+    private var systemSamples: [Float] = []
+
+    /// 系统队列最多保留 10 秒的样本，避免麦克风长时间不活跃时无限增长
+    private let maxBufferedSamples: Int = 16000 * 10
+
+    /// 系统音频回调调用：追加样本到队列
+    func pushSystemSamples(_ samples: [Float]) {
+        lock.lock()
+        defer { lock.unlock() }
+        systemSamples.append(contentsOf: samples)
+        if systemSamples.count > maxBufferedSamples {
+            let overflow = systemSamples.count - maxBufferedSamples
+            systemSamples.removeFirst(overflow)
+        }
+    }
+
+    /// 麦克风驱动调用：取出 count 个系统样本；不足时用 0 填充
+    func popSystemSamples(count: Int) -> [Float] {
+        lock.lock()
+        defer { lock.unlock() }
+        if systemSamples.count >= count {
+            let out = Array(systemSamples.prefix(count))
+            systemSamples.removeFirst(count)
+            return out
+        }
+        let available = systemSamples
+        systemSamples = []
+        return available + Array(repeating: 0, count: count - available.count)
+    }
+
+    func drain() {
+        lock.lock()
+        systemSamples = []
+        lock.unlock()
+    }
+}
+
+// MARK: - CMSampleBuffer → 16kHz Float32 mono 样本转换
+
+/// 有状态的转换辅助：CMSampleBuffer → [Float]（16kHz Float32 mono）
+/// 复用 AVAudioConverter 避免每次回调都重建。用于 .both 模式把系统音频样本压入混合器队列。
+final class MonoFloat32Converter: @unchecked Sendable {
+    private var converter: AVAudioConverter?
+    private let targetFormat: AVAudioFormat
+
+    init(targetSampleRate: Int = 16000) {
+        self.targetFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: Double(targetSampleRate),
+            channels: 1,
+            interleaved: false
+        )!
+    }
+
+    func convert(_ sampleBuffer: CMSampleBuffer) -> [Float]? {
+        guard let pcm = sampleBuffer.toPCMBuffer() else { return nil }
+
+        // 源格式已经与目标一致，直接返回样本
+        if pcm.format.sampleRate == targetFormat.sampleRate
+            && pcm.format.commonFormat == targetFormat.commonFormat
+            && pcm.format.channelCount == targetFormat.channelCount {
+            guard let data = pcm.floatChannelData?[0] else { return nil }
+            return Array(UnsafeBufferPointer(start: data, count: Int(pcm.frameLength)))
+        }
+
+        if converter == nil {
+            converter = AVAudioConverter(from: pcm.format, to: targetFormat)
+        }
+        guard let converter else { return nil }
+
+        let ratio = targetFormat.sampleRate / pcm.format.sampleRate
+        let capacity = AVAudioFrameCount(Double(pcm.frameLength) * ratio) + 1
+        guard let output = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: capacity) else { return nil }
+
+        var error: NSError?
+        var consumed = false
+        converter.convert(to: output, error: &error) { _, outStatus in
+            if consumed {
+                outStatus.pointee = .noDataNow
+                return nil
+            }
+            consumed = true
+            outStatus.pointee = .haveData
+            return pcm
+        }
+
+        guard error == nil, output.frameLength > 0, let data = output.floatChannelData?[0] else {
+            return nil
+        }
+        return Array(UnsafeBufferPointer(start: data, count: Int(output.frameLength)))
+    }
+}


### PR DESCRIPTION
Addresses #12.

## Summary

Adds system audio capture to Meeting mode so online meetings (Zoom / 腾讯会议 / 飞书 / Teams etc.) can transcribe **both sides** of the conversation. Today, `AVCaptureDevice.default(for: .audio)` only captures the microphone, which misses the remote participants entirely when the user wears headphones.

New config key `meeting.audio_source` in `~/.we/config.json`:

| value | behavior |
|---|---|
| `"mic"` *(default)* | current behavior, unchanged |
| `"system"` | ScreenCaptureKit SCStream only — just the remote side |
| `"both"` | mic + system audio, mixed in real time |

Default is `mic` so existing users see no behavior change.

## How it works

```
.mic    : AVCaptureSession → MeetingCaptureDelegate → SA + WAV + diarization  (unchanged)
.system : SCStream → MeetingCaptureDelegate.handleSystemSampleBuffer → same pipeline
.both   : AVCaptureSession (mic) → MeetingCaptureDelegate (with mixer) ──┐
          SCStream (system) → Float32 16kHz mono → AudioMixer ───────────┤
                                                                         │
          mic is the primary clock. On each mic callback, the delegate   │
          pops N system samples from the mixer (zero-padded if queue     │
          is short), sums sample-wise with mic, hard-clips to [-1, 1],   │
          and feeds the summed buffer through the existing SA / WAV /    │
          diarization branches.
```

The downstream pipeline (SpeechAnalyzer / FluidAudio / WAV writer) is unchanged — changes are isolated to capture + an optional mixing stage at the head of `MeetingCaptureDelegate`.

## Files

- `client/Sources/SystemAudioCapture.swift` *(new, ~195 lines)*
  - `SystemAudioCapture` — SCStream wrapper with `capturesAudio=true`, 2×2 dummy video (SCK requires non-zero video), `excludesCurrentProcessAudio=true`
  - `AudioMixer` — thread-safe Float32 queue with zero-padded `popSystemSamples(count:)` and 10s max buffer to avoid unbounded growth
  - `MonoFloat32Converter` — stateful CMSampleBuffer → `[Float]` @ 16kHz mono (reuses `AVAudioConverter`)
- `client/Sources/MeetingSession.swift`
  - `AudioSourceMode` enum
  - `start()` reads mode from config and branches: configures `AVCaptureSession` for `.mic`/`.both`, `SystemAudioCapture` for `.system`/`.both`, `AudioMixer` only for `.both`
  - `stop()` tears down both sources + drains mixer
  - `MeetingCaptureDelegate` gets an optional `mixer` and new `handleSystemSampleBuffer(_:)`; `captureOutput` is now a thin forwarder to a shared `handleSampleBuffer(_:)` that does the mixing + 3-way fanout
  - `mixWithSystemAudio(micBuffer:mixer:)` — mic→dia format convert, pop equal-length system samples, sum + hard-clip
  - Graceful degradation: if SCK fails in `.both`, falls back to mic-only rather than aborting the meeting
- `client/Sources/RuntimeConfig.swift`
  - `meetingConfig` accessor + default `"meeting": { "audio_source": "mic" }`

## Open questions

A few things I didn't touch because you mentioned architectural changes are coming — happy to adjust either way:

1. **UI** — no menu-bar toggle added. Currently config-file only. Want a live switcher?
2. **Clipping** — `max(-1, min(1, mic + sys))` is the cheapest option. Works fine in my testing but two loud sources distort. Easy to swap for 0.5× per-source attenuation or soft clip if preferred.
3. **WAV format in `.both`** — mixed buffer is 16kHz Float32 mono → converted to analyzer format for WAV (same as mic-only path). The file is slightly different from today's (mono instead of whatever mic native was), but `afinfo` reads it fine and SA transcribes from it.
4. **Mic still drives the clock in `.both`** — if the user is silent (no mic callbacks), mixed output stops emitting even though system audio is flowing. This matches the observed behavior for muted-system edge cases. If you want system-driven or tick-driven output, happy to refactor.

## Testing

- Built clean on macOS 26.3, Swift 6.2 (warnings are pre-existing `AVAudioConverter.convert` Sendable warnings consistent with the pattern in `VoiceSession.swift`)
- Tested `.both` mode with a YouTube video + mic narration — both sides show up in the transcript; speaker diarization labels them as separate speakers
- Tested `.mic` mode (default) — behavior matches main
- System volume attenuation was verified to not affect captured audio level (SCK taps upstream of the volume slider)

## Test plan

- [ ] \`.mic\` mode (default): existing behavior unchanged
- [ ] \`.system\` mode: Zoom/腾讯会议 remote audio transcribed, no mic input
- [ ] \`.both\` mode: both sides transcribed in the same meeting
- [ ] First-run Screen Recording permission prompt appears and works
- [ ] \`.both\` fallback to mic-only when Screen Recording denied